### PR TITLE
Try to fix parsing of sysctl output when 'permission denied' appears in the stderr stream

### DIFF
--- a/lib/puppet/provider/sysctl/linux.rb
+++ b/lib/puppet/provider/sysctl/linux.rb
@@ -1,7 +1,29 @@
+require 'puppet/provider'
+
 Puppet::Type.type(:sysctl).provide(:linux) do
 
   confine  :kernel => 'linux'
-  commands :sysctl => 'sysctl'
+
+  class CommandDefinerNoMerge < Puppet::Provider::CommandDefiner
+    def command
+      @confiner.confine :exists => @path, :for_binary => true
+      Puppet::Provider::Command.new(@name, @path, Puppet::Util, Puppet::Util::Execution, { :failonfail => true, :combine => false, :custom_environment => @custom_environment })
+    end
+  end
+
+  def self.has_nomerge_command(name, path, &block)
+    name = name.intern
+    command = CommandDefinerNoMerge.define(name, path, self, &block)
+
+    @commands[name] = command.executable
+
+    create_class_and_instance_method(name) do |*args|
+      return command.execute(*args)
+    end
+  end
+
+  has_nomerge_command(:sysctl, 'sysctl') do
+  end
 
   def exists?
     @property_hash[:ensure] == :present


### PR DESCRIPTION
stdout and stderr being merged by the command breaks things for me.

On (some) of my machines, when I run:

sudo sysctl -a

I get:

```
....
net.ipv6.conf.vlan4.accept_dad = 1
net.ipv6.ip6frag_high_thresh = 262144
net.ipv6.ip6frag_low_thresh = 196608
net.ipv6.ip6frag_time = 60
error: permission denied on key 'net.ipv6.route.flush'
net.ipv6.route.gc_thresh = 1024
net.ipv6.route.max_size = 4096
....
```

The merging of stdout and stderr means that the lines we actually see and up being:

```
"net.ipv4.ip_forwarderror: permission denied on key 'net.ipv4.route.flush'"
" = 1"
```

This obviously breaks the parsing for some fields (those which are near a 'permission denied').

The only fix I've come up with for this is to stop merging stderr into the command output.

I'm not particularly happy with this fix (and I've currently only done it for Linux, not Darwin), however I can't see a better/nicer way to do this (and https://ask.puppetlabs.com/question/6299/combine-false-for-provider-commands/ hasn't turned up any suggestions).

I can however confirm that this patch does definitely fix the issues I've been seeing.

Look forward to your thoughts / comments.
