### PR TITLE
Added ability to set resources from ENC et all

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+1.1.1
+
+Can define sysctl values directly via ENC/Hiera
+
 1.1.0
 
 Acceptance tests!

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ EXAMPLE USAGE:
       value     => '32768 61000',
     }
 
+    class { 'sysctl':
+      set = {'net.ipv4.ip_local_port_range' => { value => '32768 61000', permanent => 'yes', ensure => 'present',
+    }
+
 There are some things to be aware of - namely:
 
 First - by default the available params are available on your platform by running sysctl -a

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,17 +1,19 @@
 # Class: sysctl
 #
-# This class is a stub for a module that provides a sysctl type and
-# 2 providers:
-#   linux.rb
-#   darwin.rb
+# This class is a stub for a module that provides a sysctl type.
+#   It will create sysctl values if you if passed via 'set'
 #
 # Parameters:
-#   N/A
+#   set = {'key' => { value => 'txt', permanent => 'yes', ensure => 'present',}
 #
 # Requires:
 #
 # Sample Usage:
 #
-class sysctl {
-  # foooooooooooo
+class sysctl ($set = {}) {
+  validate_hash($set)
+
+  if $set {
+    create_resources('sysctl', $set)
+  }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "fiddyspence-sysctl",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Chris Spence",
   "license": "Apache-2.0",
   "summary": "sysctl type and provider",
@@ -23,5 +23,9 @@
     }
    ],
   "dependencies": [
+    {
+      "name": "puppetlabs-stdlib",
+      "version_range": ">= 1.0.0"
+    }
   ]
 }

--- a/spec/init.pp
+++ b/spec/init.pp
@@ -1,0 +1,1 @@
+include sysctl


### PR DESCRIPTION
This code adds the ability to simply define sysctl values directly via ENC/Hiera rather than making another class to contain the resource definitions.
