### PR TITLE
Set permanent default to :true

### DIFF
--- a/lib/puppet/type/sysctl.rb
+++ b/lib/puppet/type/sysctl.rb
@@ -23,6 +23,7 @@ Puppet::Type.newtype(:sysctl) do
     newvalues(:true, :false)
     aliasvalue('yes', :true)
     aliasvalue('no', :false)
+    defaultto :true
   end
 
   newparam(:path) do


### PR DESCRIPTION
I'd expect permanent to default to 'true' as we've requested the change to the system state and this state should be persistent between runs.  Since we could reboot the box between runs, permanent true made the most sense to me.
